### PR TITLE
Fixed ConversionCog to convert multiple values

### DIFF
--- a/cogs/conversion.py
+++ b/cogs/conversion.py
@@ -48,7 +48,8 @@ class ConversionCog(commands.Cog):
 
     def convert_height_to_cm(self, match: re.Match) -> str:
         """
-        Regex callback function that converts each height match into a centimeter value, returning the height converted string.
+        Regex callback function that converts each height match into a centimeter value.
+        This returns the height converted string.
 
         Args:
             match (re.Match): The match found by the height regex
@@ -65,7 +66,8 @@ class ConversionCog(commands.Cog):
 
     def convert_weight_to_kg(self, match: re.Match) -> str:
         """
-        Regex callback function that converts each `lb` match into a `kg` value, returning the weight converted string.
+        Regex callback function that converts each `lb` match into a `kg` value.
+        This returns the weight converted string.
 
         Args:
             match (re.Match): The match found by the weight regex

--- a/cogs/conversion.py
+++ b/cogs/conversion.py
@@ -10,9 +10,7 @@ class ConversionCog(commands.Cog):
     """
 
     # Compiled regular expressions as it may improve performance slightly
-    HEIGHT_PATTERN: re.Pattern = re.compile(
-        r"(\d+)\s?['’]\s?(\d+)\s?", re.IGNORECASE
-    )
+    HEIGHT_PATTERN: re.Pattern = re.compile(r"(\d+)\s?['’]\s?(\d+)\s?", re.IGNORECASE)
     WEIGHT_PATTERN: re.Pattern = re.compile(r"(\d+(?:\.\d+)?)\s?(?:lbs?|pounds?)", re.IGNORECASE)
 
     def __init__(self, bot: commands.Bot):
@@ -35,7 +33,9 @@ class ConversionCog(commands.Cog):
 
         # Converts the imperial units to metric units
         converted_heights = ConversionCog.HEIGHT_PATTERN.sub(self.convert_height_to_cm, content)
-        converted_weights = ConversionCog.WEIGHT_PATTERN.sub(self.convert_weight_to_kg, converted_heights)
+        converted_weights = ConversionCog.WEIGHT_PATTERN.sub(
+            self.convert_weight_to_kg, converted_heights
+        )
 
         # Send the converted message back to the channel
         if converted_weights != content:
@@ -49,12 +49,13 @@ class ConversionCog(commands.Cog):
             match (re.Match): The match found by the height regex
         """
 
-        feet : int = int(match.group(1))
-        inches : int = int(match.group(2))
-        if feet is None or match.group(2) is None: return
+        feet: int = int(match.group(1))
+        inches: int = int(match.group(2))
+        if feet is None or match.group(2) is None:
+            return
 
-        total_inches : int = feet * 12 + inches
-        cm : int = round(total_inches * 2.54)
+        total_inches: int = feet * 12 + inches
+        cm: int = round(total_inches * 2.54)
         return f"{cm} cm "
 
     def convert_weight_to_kg(self, match: re.Match) -> str:
@@ -65,10 +66,11 @@ class ConversionCog(commands.Cog):
             match (re.Match): The match found by the weight regex
         """
 
-        lbs : float = float(match.group(1))
-        if lbs is None: return
+        lbs: float = float(match.group(1))
+        if lbs is None:
+            return
 
-        kg : float = round(lbs * 0.45359237, 1)
+        kg: float = round(lbs * 0.45359237, 1)
         return f"{kg} kg"
 
 

--- a/cogs/conversion.py
+++ b/cogs/conversion.py
@@ -3,6 +3,11 @@ import re
 import discord
 from discord.ext import commands
 
+"""
+Discord cog module for converting imperial units to metric.
+This can be loaded via an extension.
+"""
+
 
 class ConversionCog(commands.Cog):
     """

--- a/cogs/conversion.py
+++ b/cogs/conversion.py
@@ -11,7 +11,7 @@ class ConversionCog(commands.Cog):
 
     # Compiled regular expressions as it may improve performance slightly
     HEIGHT_PATTERN: re.Pattern = re.compile(
-        r"(\d+)\s?['’]\s?(\d+)\s?(?:\"|inches?)?", re.IGNORECASE
+        r"(\d+)\s?['’]\s?(\d+)\s?", re.IGNORECASE
     )
     WEIGHT_PATTERN: re.Pattern = re.compile(r"(\d+(?:\.\d+)?)\s?(?:lbs?|pounds?)", re.IGNORECASE)
 


### PR DESCRIPTION
As referenced in #34 issue, the current ConversionCog only converts one `lb` or height value and it substitutes the rest of the height or weight values with that value.

For example:
"I am a 6'0 man and my friend is 5'4" 
would be converted to...
"I am a 183 cm man and my friend is 183 cm"

The current code currently hasn't been formatted properly yet.